### PR TITLE
upgpkg: snapd 2.72-1

### DIFF
--- a/snapd/.SRCINFO
+++ b/snapd/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = snapd
 	pkgdesc = Service and tools for management of snap packages.
-	pkgver = 2.71
+	pkgver = 2.72
 	pkgrel = 1
 	url = https://github.com/snapcore/snapd
 	install = snapd.install
@@ -30,7 +30,9 @@ pkgbase = snapd
 	options = !strip
 	options = emptydirs
 	options = !lto
-	source = snapd-2.71.tar.xz::https://github.com/snapcore/snapd/releases/download/2.71/snapd_2.71.vendor.tar.xz
-	sha256sums = 426fced4b4e06fd36a10f18e6fe1efd21281c4fc73f4ada8bba9db2e80c7ea34
+	source = snapd-2.72.tar.xz::https://github.com/snapcore/snapd/releases/download/2.72/snapd_2.72.vendor.tar.xz
+	source = 0001-cmd-snap-confine-snap-confine-update-AppArmor-profil.patch
+	sha256sums = 53d74e663527bae667a254da8a029aa4b0b8f559ca515d214da8dbb29dc6ccc7
+	sha256sums = 3584cdfabde12d1739342bc1bd73705bb5d9d3aed4ab038a478657fd4ede7364
 
 pkgname = snapd

--- a/snapd/0001-cmd-snap-confine-snap-confine-update-AppArmor-profil.patch
+++ b/snapd/0001-cmd-snap-confine-snap-confine-update-AppArmor-profil.patch
@@ -1,0 +1,46 @@
+From 079605bdacc82243efdd44ec6d81bc4a93d2859f Mon Sep 17 00:00:00 2001
+Message-ID: <079605bdacc82243efdd44ec6d81bc4a93d2859f.1760438845.git.maciej.borzecki@canonical.com>
+From: Maciej Borzecki <maciej.borzecki@canonical.com>
+Date: Mon, 13 Oct 2025 19:15:54 +0200
+Subject: [PATCH] cmd/snap-confine/snap-confine: update AppArmor profile to
+ allow read/write to journal (#16131)
+
+Update the AppArmor profile of snap-confine to allow read-write access
+to the journal provided stdout. This scenario occurs when snap-confine
+is invoked to set up a sandbox for snap services.
+
+Fixes: LP#2127244 LP#2121169
+Related: SNAPDENG-35767
+
+Signed-off-by: Maciej Borzecki <maciej.borzecki@canonical.com>
+---
+ cmd/snap-confine/snap-confine.apparmor.in | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/cmd/snap-confine/snap-confine.apparmor.in b/cmd/snap-confine/snap-confine.apparmor.in
+index a653f1f70f7a7abfadc6414fb78a6c8ae3273e67..51964ad7ec2bdc714292310cee507de34498eacf 100644
+--- a/cmd/snap-confine/snap-confine.apparmor.in
++++ b/cmd/snap-confine/snap-confine.apparmor.in
+@@ -66,6 +66,9 @@
+     /dev/pts/[0-9]* rw,
+     /dev/tty rw,
+ 
++    # Stdout may be inherited from systemd. This is normally provided by <abstractions/base>
++    /{,var/}run/systemd/journal/stdout rw,
++
+     # SNAP_MOUNT_DIR probe logic
+     /proc/1/root/snap r,
+ 
+@@ -546,6 +549,9 @@
+         /dev/random r,
+         /dev/urandom r,
+ 
++        # Stdout may be inherited from systemd. This is normally provided by <abstractions/base>
++        /{,var/}run/systemd/journal/stdout rw,
++
+         capability dac_override,
+         capability sys_ptrace,
+         capability sys_admin,
+-- 
+2.51.0
+

--- a/snapd/PKGBUILD
+++ b/snapd/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'libcap' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.71
+pkgver=2.72
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"
@@ -19,9 +19,11 @@ options=('!strip' 'emptydirs' '!lto')
 install=snapd.install
 source=(
   "$pkgname-$pkgver.tar.xz::https://github.com/snapcore/${pkgname}/releases/download/${pkgver}/${pkgname}_${pkgver}.vendor.tar.xz"
+  "0001-cmd-snap-confine-snap-confine-update-AppArmor-profil.patch"
 )
 
-sha256sums=('426fced4b4e06fd36a10f18e6fe1efd21281c4fc73f4ada8bba9db2e80c7ea34')
+sha256sums=('53d74e663527bae667a254da8a029aa4b0b8f559ca515d214da8dbb29dc6ccc7'
+           '3584cdfabde12d1739342bc1bd73705bb5d9d3aed4ab038a478657fd4ede7364')
 
 
 prepare() {
@@ -142,6 +144,9 @@ package() {
 
   # Install the "info" data file with snapd version
   install -m 644 -D "data/info" "$pkgdir/usr/lib/snapd/info"
+
+  # Install the news file
+  install -m 644 -D "NEWS.md" "$pkgdir/usr/share/doc/snapd/NEWS.md"
 
   # these locations are created at runtime but were not part of the packaging
   # previously, thus would trigger a file conflict on upgrade

--- a/snapd/snapd.install
+++ b/snapd/snapd.install
@@ -1,5 +1,5 @@
 _set_snap_confine_caps() {
-  /usr/bin/setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.caps
+  /usr/bin/setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.v2-only.caps
 }
 
 post_install() {


### PR DESCRIPTION
Upstream release.

Cherry pick patch from https://github.com/canonical/snapd/pull/16131.